### PR TITLE
Update README.mdx

### DIFF
--- a/README.mdx
+++ b/README.mdx
@@ -47,6 +47,12 @@ Patrick Brouwer
 npm install @inlet/react-pixi --save
 ```
 
+ReactPixi depends on pixi.js so be sure you've got that installed too!
+
+```bash
+npm install pixi.js --save
+```
+
 or use [CDN](/cdn-links):
 
 ```html


### PR DESCRIPTION
Updated docs to guide new readers to install pixi.js in order to use this package

**Description:**
As a new user of this package I had absolutely no idea that Pixi.js was required to use this package. I googled the error and stumbled upon several articles from as far back as 2018 where people had the same issue. 

To remedy this I've just added a note in the README that the user needs to have Pixi.js installed to use this package.
