### PR TITLE
Enable tree-shaking by setting sideEffects to false

### DIFF
--- a/animated/package.json
+++ b/animated/package.json
@@ -3,5 +3,6 @@
   "umd:main": "umd.js",
   "module": "module.js",
   "jsnext:main": "module.js",
-  "typings": "./animated.d.ts"
+  "typings": "./animated.d.ts",
+  "sideEffects": false
 }

--- a/legacy/package.json
+++ b/legacy/package.json
@@ -3,5 +3,6 @@
   "umd:main": "umd.js",
   "module": "module.js",
   "jsnext:main": "module.js",
-  "typings": "../index.d.ts"
+  "typings": "../index.d.ts",
+  "sideEffects": false
 }

--- a/package.json
+++ b/package.json
@@ -122,5 +122,6 @@
     "get-pkg-repo": "4.1.1",
     "hosted-git-info": "^2.1.4"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "sideEffects": false
 }


### PR DESCRIPTION
**Description:**

By adding the `sideEffects` property to the package.json file, we enable bundlers to remove unused code. The following reports show the difference between having this change and not having it:

|Before|After|
|--|--|
|![image](https://user-images.githubusercontent.com/858829/209857335-50f96c74-4ba7-4fc6-a62f-482ae19406f3.png)|![image](https://user-images.githubusercontent.com/858829/209856823-b2db4e97-b18e-4882-908d-c6b231115668.png)|

**Related issue (if exists):**
https://github.com/pixijs/pixi-react/issues/356
