### PR TITLE
Move sideEffects false to each package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "workspaces": [
     "packages/*"
   ],
-  "sideEffects": false,
   "scripts": {
     "build": "nx run-many --target=build --all --parallel",
     "build:force": "nx run-many --target=build --all --parallel --skip-nx-cache",

--- a/packages/animated-legacy/package.json
+++ b/packages/animated-legacy/package.json
@@ -28,6 +28,7 @@
     "test": "jest --silent",
     "test:watch": "jest --watch"
   },
+  "sideEffects": false,
   "dependencies": {
     "@pixi/react-legacy": "*"
   },

--- a/packages/animated/package.json
+++ b/packages/animated/package.json
@@ -28,6 +28,7 @@
     "test": "jest --silent",
     "test:watch": "jest --watch"
   },
+  "sideEffects": false,
   "dependencies": {
     "@pixi/react": "*"
   },

--- a/packages/react-legacy/package.json
+++ b/packages/react-legacy/package.json
@@ -29,6 +29,7 @@
     "test": "jest --silent",
     "test:watch": "jest --watch"
   },
+  "sideEffects": false,
   "dependencies": {
     "@pixi/react": "*"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -29,6 +29,7 @@
     "test": "jest --silent",
     "test:watch": "jest --watch"
   },
+  "sideEffects": false,
   "dependencies": {
     "lodash.isnil": "4.0.0",
     "lodash.times": "4.3.2",


### PR DESCRIPTION
`sideEffect: false` was added to root `package.json` by mistake, this PR moves it to each package