### PR TITLE
Update docs version and fix baseUrl

### DIFF
--- a/packages/docs/docusaurus.config.js
+++ b/packages/docs/docusaurus.config.js
@@ -8,8 +8,8 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 const config = {
     title: 'ReactPixi',
     tagline: 'Write PixiJS applications using React declarative style.',
-    url: 'https://reactpixi.org/',
-    baseUrl: '/',
+    url: 'http://pixijs.io/',
+    baseUrl: '/pixi-react/',
     onBrokenLinks: 'throw',
     onBrokenMarkdownLinks: 'warn',
     favicon: 'img/favicon.png',

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pixi/react-docs",
-  "version": "7.0.0-alpha.0",
+  "version": "7.0.0-alpha.1",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
Bump `docs` to `v7.0.0-alpha.1` and fix the base url
