### PR TITLE
Fix borked versions

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useWorkspaces": true,
-  "version": "7.0.0-alpha.2"
+  "version": "7.0.0"
 }

--- a/packages/animated/package.json
+++ b/packages/animated/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pixi/react-animated",
-  "version": "7.0.0-alpha.2",
+  "version": "7.0.0",
   "description": "Animate your @pixi/react components with react-spring",
   "repository": {
     "type": "git",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pixi/react",
-  "version": "7.0.0-alpha.2",
+  "version": "7.0.0",
   "description": "Write PixiJS applications using React declarative style.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The version numbers were reverted to an alpha version when I fixed the `v7.0.0` tag and release not being built from master.
I'll recreate the tag and release after merging this.