### PR TITLE
Fix Container TS types bug

### DIFF
--- a/packages/animated/index.d.ts
+++ b/packages/animated/index.d.ts
@@ -356,7 +356,7 @@ declare namespace _ReactPixi {
 // components
 export const Text: AnimatedComponent<React.FC<_ReactPixi.IText>>;
 export const Sprite: AnimatedComponent<React.FC<_ReactPixi.ISprite>>;
-export const Container: AnimatedComponent<React.FC<_ReactPixi.IContainer>>;
+export const Container: AnimatedComponent<React.FC<React.PropsWithChildren<_ReactPixi.IContainer>>>;
 export const Graphics: AnimatedComponent<React.FC<_ReactPixi.IGraphics>>;
 export const BitmapText: AnimatedComponent<React.FC<_ReactPixi.IBitmapText>>;
 export const NineSlicePlane: AnimatedComponent<React.FC<_ReactPixi.INineSlicePlane>>;
@@ -405,7 +405,7 @@ export class Stage extends React.Component<_ReactPixi.IStage> { }
  *   }
  * });
  */
-export const PixiComponent: <Props, PixiInstance extends PixiDisplayObject>(
+export const PixiComponent: <Props extends { [key: string]: any; }, PixiInstance extends PixiDisplayObject>(
   componentName: string,
   lifecycle: _ReactPixi.ICustomComponent<Props, PixiInstance>
 ) => AnimatedComponent<React.FC<Props & { ref?: React.Ref<PixiInstance> }>>;

--- a/packages/react/index.d.ts
+++ b/packages/react/index.d.ts
@@ -376,7 +376,7 @@ declare namespace _ReactPixi
 // components
 export const Text: React.FC<_ReactPixi.IText>;
 export const Sprite: React.FC<_ReactPixi.ISprite>;
-export const Container: React.FC<_ReactPixi.IContainer>;
+export const Container: React.FC<React.PropsWithChildren<_ReactPixi.IContainer>>;
 export const Graphics: React.FC<_ReactPixi.IGraphics>;
 export const BitmapText: React.FC<_ReactPixi.IBitmapText>;
 export const NineSlicePlane: React.FC<_ReactPixi.INineSlicePlane>;
@@ -428,7 +428,7 @@ export class Stage extends React.Component<_ReactPixi.IStage> {}
  *   }
  * });
  */
-export const PixiComponent: <Props, PixiInstance extends PixiDisplayObject>(
+export const PixiComponent: <Props extends { [key: string]: any; }, PixiInstance extends PixiDisplayObject>(
     componentName: string,
     lifecycle: _ReactPixi.ICustomComponent<Props, PixiInstance>
 ) => React.FC<Props & { ref?: React.Ref<PixiInstance> }>;


### PR DESCRIPTION
Fixes: https://github.com/pixijs/pixi-react/issues/350

According to https://github.com/pixijs/pixi-react/issues/350#issuecomment-1413422066 and as per [suggestions on the Discord](https://discord.com/channels/734147990985375826/968068526566965279/1068509211052482580):

> Basically you have to replace each React.FC with something that adds children prop

> PropsWithChildren<T>  is mainly used for that right now

This should fix the TS issue with Container

