### PR TITLE
Fix typings for sprite with children

### DIFF
--- a/packages/animated/index.d.ts
+++ b/packages/animated/index.d.ts
@@ -186,7 +186,7 @@ declare namespace _ReactPixi {
   type Container<T extends PixiDisplayObject, U = {}> = Partial<
     Omit<T, 'children' | P | ReadonlyKeys<T> | keyof U> &
     WithPointLike<P>
-  > & U & InteractionEvents & { ref?: React.Ref<T> }  & {children?: React.ReactElement | React.ReactElement[] | React.Factory<any>};
+  > & U & InteractionEvents & { ref?: React.Ref<T> };
 
   type IContainer = Container<PixiContainer>;
   type ISprite = Container<PixiSprite, WithSource>;

--- a/packages/animated/index.d.ts
+++ b/packages/animated/index.d.ts
@@ -360,7 +360,7 @@ export const Container: AnimatedComponent<React.FC<React.PropsWithChildren<_Reac
 export const Graphics: AnimatedComponent<React.FC<_ReactPixi.IGraphics>>;
 export const BitmapText: AnimatedComponent<React.FC<_ReactPixi.IBitmapText>>;
 export const NineSlicePlane: AnimatedComponent<React.FC<_ReactPixi.INineSlicePlane>>;
-export const ParticleContainer: AnimatedComponent<React.FC<_ReactPixi.IParticleContainer>>;
+export const ParticleContainer: AnimatedComponent<React.FC<React.PropsWithChildren<_ReactPixi.IParticleContainer>>>;
 export const TilingSprite: AnimatedComponent<React.FC<_ReactPixi.ITilingSprite>>;
 export const SimpleRope: AnimatedComponent<React.FC<_ReactPixi.ISimpleRope>>;
 export const SimpleMesh: AnimatedComponent<React.FC<_ReactPixi.ISimpleMesh>>;

--- a/packages/animated/index.d.ts
+++ b/packages/animated/index.d.ts
@@ -186,7 +186,7 @@ declare namespace _ReactPixi {
   type Container<T extends PixiDisplayObject, U = {}> = Partial<
     Omit<T, 'children' | P | ReadonlyKeys<T> | keyof U> &
     WithPointLike<P>
-  > & U & InteractionEvents & { ref?: React.Ref<T> };
+  > & U & InteractionEvents & { ref?: React.Ref<T> }  & {children?: React.ReactElement | React.ReactElement[] | React.Factory<any>};
 
   type IContainer = Container<PixiContainer>;
   type ISprite = Container<PixiSprite, WithSource>;

--- a/packages/animated/index.d.ts
+++ b/packages/animated/index.d.ts
@@ -355,7 +355,7 @@ declare namespace _ReactPixi {
 
 // components
 export const Text: AnimatedComponent<React.FC<_ReactPixi.IText>>;
-export const Sprite: AnimatedComponent<React.FC<_ReactPixi.ISprite>>;
+export const Sprite: AnimatedComponent<React.FC<React.PropsWithChildren<_ReactPixi.ISprite>>>;
 export const Container: AnimatedComponent<React.FC<React.PropsWithChildren<_ReactPixi.IContainer>>>;
 export const Graphics: AnimatedComponent<React.FC<_ReactPixi.IGraphics>>;
 export const BitmapText: AnimatedComponent<React.FC<_ReactPixi.IBitmapText>>;

--- a/packages/react/index.d.ts
+++ b/packages/react/index.d.ts
@@ -186,9 +186,9 @@ declare namespace _ReactPixi
   type P = 'position' | 'scale' | 'pivot' | 'anchor' | 'skew';
 
   type Container<T extends PixiDisplayObject, U = {}> = Partial<
-  Omit<T, 'children' | P | ReadonlyKeys<T> | keyof U> &
-  WithPointLike<P>
-  > & U & InteractionEvents & { ref?: React.Ref<T> };
+    Omit<T, 'children' | P | ReadonlyKeys<T> | keyof U> &
+    WithPointLike<P>
+  > & U & InteractionEvents & { ref?: React.Ref<T> } & {children?: React.ReactElement | React.ReactElement[] | React.Factory<any>};
 
   type IContainer = Container<PixiContainer>;
   type ISprite = Container<PixiSprite, WithSource>;

--- a/packages/react/index.d.ts
+++ b/packages/react/index.d.ts
@@ -186,9 +186,9 @@ declare namespace _ReactPixi
   type P = 'position' | 'scale' | 'pivot' | 'anchor' | 'skew';
 
   type Container<T extends PixiDisplayObject, U = {}> = Partial<
-    Omit<T, 'children' | P | ReadonlyKeys<T> | keyof U> &
-    WithPointLike<P>
-  > & U & InteractionEvents & { ref?: React.Ref<T> } & {children?: React.ReactElement | React.ReactElement[] | React.Factory<any>};
+  Omit<T, 'children' | P | ReadonlyKeys<T> | keyof U> &
+  WithPointLike<P>
+  > & U & InteractionEvents & { ref?: React.Ref<T> };
 
   type IContainer = Container<PixiContainer>;
   type ISprite = Container<PixiSprite, WithSource>;

--- a/packages/react/index.d.ts
+++ b/packages/react/index.d.ts
@@ -375,7 +375,7 @@ declare namespace _ReactPixi
 
 // components
 export const Text: React.FC<_ReactPixi.IText>;
-export const Sprite: React.FC<_ReactPixi.ISprite>;
+export const Sprite: React.FC<React.PropsWithChildren<_ReactPixi.ISprite>>;
 export const Container: React.FC<React.PropsWithChildren<_ReactPixi.IContainer>>;
 export const Graphics: React.FC<_ReactPixi.IGraphics>;
 export const BitmapText: React.FC<_ReactPixi.IBitmapText>;

--- a/packages/react/index.d.ts
+++ b/packages/react/index.d.ts
@@ -380,7 +380,7 @@ export const Container: React.FC<React.PropsWithChildren<_ReactPixi.IContainer>>
 export const Graphics: React.FC<_ReactPixi.IGraphics>;
 export const BitmapText: React.FC<_ReactPixi.IBitmapText>;
 export const NineSlicePlane: React.FC<_ReactPixi.INineSlicePlane>;
-export const ParticleContainer: React.FC<_ReactPixi.IParticleContainer>;
+export const ParticleContainer: React.FC<React.PropsWithChildren<_ReactPixi.IParticleContainer>>;
 export const TilingSprite: React.FC<_ReactPixi.ITilingSprite>;
 export const SimpleRope: React.FC<_ReactPixi.ISimpleRope>;
 export const SimpleMesh: React.FC<_ReactPixi.ISimpleMesh>;


### PR DESCRIPTION
Fix typings for Sprite with children.
For example this code:
```
<Container x={100} y={100}>
  <Sprite texture={Assets.cache.get('/assets/texture.png')} scale={new Point(0.4, 0.4)}>
    <Text
      text="I am text as sprite's child"
      style={new TextStyle({ fill: 0xffffff })}
    />
  </Sprite>
</Container>
```
generates Sprite type error:
`Type '{ children: Element; texture: Texture<Resource>; scale: Point; }' is not assignable to type 'IntrinsicAttributes & Partial<Omit<Sprite, P | ReadonlyKeys<Sprite> | keyof WithSource> & WithPointLike<P>> & WithSource & InteractionEvents & { ...; }'.   Property 'children' does not exist on type 'IntrinsicAttributes & Partial<Omit<Sprite, P | ReadonlyKeys<Sprite> | keyof WithSource> & WithPointLike<P>> & WithSource & InteractionEvents & { ...; }'.`
