### PR TITLE
Add AppProvider usage description in hooks docs

### DIFF
--- a/packages/docs/docs/hooks/Hooks.mdx
+++ b/packages/docs/docs/hooks/Hooks.mdx
@@ -2,7 +2,7 @@
 
 Pixi React now support [React hooks](https://reactjs.org/docs/hooks-reference.html) 🌟
 
-Pixi Hooks rely on [React Context](https://reactjs.org/docs/context.html) and must be called inside an `AppProvider`. This provider may either be created manually or through the `Stage` component and placed in a parent component. 
+Pixi Hooks rely on [React Context](https://reactjs.org/docs/context.html) and must be called inside an `AppProvider`. This provider is created automatically for you when using the `Stage` component, but will need to be added manually if using the [createRoot](https://reactjs.org/docs/react-dom-client.html#createroot) or render APIs.
 
 ## useApp
 

--- a/packages/docs/docs/hooks/Hooks.mdx
+++ b/packages/docs/docs/hooks/Hooks.mdx
@@ -2,6 +2,8 @@
 
 Pixi React now support [React hooks](https://reactjs.org/docs/hooks-reference.html) 🌟
 
+Pixi Hooks rely on [React Context](https://reactjs.org/docs/context.html) and must be called inside an `AppProvider`. This provider may either be created manually or through the `Stage` component and placed in a parent component. 
+
 ## useApp
 
 Access the `PIXI.Application` in your component


### PR DESCRIPTION
##### Description of change
Updates the hooks docs to describe that hooks must be wrapped by an AppProvider. This has been confusing to new users https://github.com/pixijs/pixi-react/issues/410

