### PR TITLE
Expose root to injected components

### DIFF
--- a/packages/react/src/utils/element.js
+++ b/packages/react/src/utils/element.js
@@ -57,7 +57,7 @@ export function createElement(type, props = {}, root = null)
 
         if (injected)
         {
-            instance = injected.create(props);
+            instance = injected.create(props, { root });
             instance.didMount = injected.didMount ? injected.didMount.bind(instance) : undefined;
             instance.willUnmount = injected.willUnmount ? injected.willUnmount.bind(instance) : undefined;
             instance.applyProps = injected.applyProps ? injected.applyProps.bind(instance) : undefined;
@@ -68,12 +68,12 @@ export function createElement(type, props = {}, root = null)
     // apply initial props!
     if (instance)
     {
+        instance.__reactpixi = {
+            root
+        };
+
         applyProps = typeof instance?.applyProps === 'function' ? instance.applyProps : applyDefaultProps;
         applyProps(instance, {}, props);
-
-        instance.__reactpixi = {
-            root,
-        };
     }
 
     return instance;

--- a/packages/react/test/element.spec.js
+++ b/packages/react/test/element.spec.js
@@ -417,7 +417,7 @@ describe('PixiComponent', () =>
         new PixiComponent('Rectangle', lifecycle);
 
         const props = { x: 100, y: 200 };
-        const element = createElement('Rectangle', props);
+        const element = createElement('Rectangle', props, null);
 
         expect(element.didMount).toBeDefined();
         expect(element.willUnmount).toBeDefined();
@@ -425,7 +425,7 @@ describe('PixiComponent', () =>
         expect(element.config).toBe(config);
         expect(element).toBeInstanceOf(Graphics);
         expect(lifecycle.create).toHaveBeenCalledTimes(1);
-        expect(lifecycle.create).toHaveBeenCalledWith(props);
+        expect(lifecycle.create).toHaveBeenCalledWith(props, { root: null });
         expect(lifecycle.applyProps).toHaveBeenCalledTimes(1);
         expect(scoped).toHaveBeenCalledTimes(1);
         expect(scoped).toHaveBeenCalledWith(element);


### PR DESCRIPTION
##### Description of change
This adds an options argument containing the pixi root to injected components, bringing them more in feature parity with native elements. It also moves the addition of the root object to the injected component before the applyProps call so that the initial applyProps call has access to it the same way native elements do.

Fixes: https://github.com/pixijs/pixi-react/issues/419

##### Pre-Merge Checklist
- [x] Tests and/or benchmarks are included
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
