### PR TITLE
Fix typo in Text.mdx

### DIFF
--- a/packages/docs/docs/components/Text.mdx
+++ b/packages/docs/docs/components/Text.mdx
@@ -30,7 +30,7 @@ Note: isSprite establishes how the Text is rendered during its whole lifecycle a
         align: 'center',
         fontFamily: '"Source Sans Pro", Helvetica, sans-serif',
         fontSize: 50,
-        fontWeight: 400,
+        fontWeight: '400',
         fill: ['#ffffff', '#00ff99'], // gradient
         stroke: '#01d27e',
         strokeThickness: 5,


### PR DESCRIPTION
VSCode API docs says `fontWeight` should be `type TextStyleFontWeight = "bold" | "normal" | "bolder" | "lighter" | "100" | "200" | "300" | "400" | "500" | "600" | "700" | "800" | "900"`

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

Fixes: <!-- Related issue if relevant --> no issue.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
I didn't change code.