### PR TITLE
Fixes AnimatedSprite component when images are updated

### DIFF
--- a/packages/react/src/components/AnimatedSprite.js
+++ b/packages/react/src/components/AnimatedSprite.js
@@ -24,7 +24,7 @@ const AnimatedSprite = (root, props) =>
     animatedSprite[isPlaying ? 'gotoAndPlay' : 'gotoAndStop'](initialFrame || 0);
     animatedSprite.applyProps = (instance, oldProps, newProps) =>
     {
-        const { textures, isPlaying, initialFrame, ...props } = newProps;
+        const { textures, isPlaying, initialFrame, images, ...props } = newProps;
 
         let changed = applyDefaultProps(instance, oldProps, props);
 

--- a/packages/react/src/components/AnimatedSprite.js
+++ b/packages/react/src/components/AnimatedSprite.js
@@ -28,6 +28,17 @@ const AnimatedSprite = (root, props) =>
 
         let changed = applyDefaultProps(instance, oldProps, props);
 
+        if (images && oldProps.images !== images)
+        {
+            const newTextures = [];
+            for (let i = 0; i < images.length; ++i)
+            {
+                newTextures.push(Texture.from(images[i]));
+            }
+            instance.textures = newTextures
+            changed = true;
+        }
+
         if (textures && oldProps.textures !== textures)
         {
             instance.textures = makeTexture(textures);

--- a/packages/react/test/element.spec.js
+++ b/packages/react/test/element.spec.js
@@ -149,7 +149,6 @@ describe('element.applyProps', () =>
     test('AnimatedSprite.applyProps with images prop exists', () =>
     {
         const element = createElement(TYPES.AnimatedSprite, { images: ['./image.png'] });
-
         expect(element).toHaveProperty('applyProps');
         expect(spy).lastCalledWith('./image.png');
     });

--- a/packages/react/test/element.spec.js
+++ b/packages/react/test/element.spec.js
@@ -157,7 +157,7 @@ describe('element.applyProps', () =>
     test('AnimatedSprite.applyProps with updated image props', () =>
     {
         const element = createElement(TYPES.AnimatedSprite, { images: ['./image.png'] });
-        const changed = element.applyProps(element, { image: './image.png' }, { image: './new-image.png' });
+        const changed = element.applyProps(element, { images: './image.png' }, { images: './new-image.png' });
         expect(spy).lastCalledWith('./new-image.png');
     });
 

--- a/packages/react/test/element.spec.js
+++ b/packages/react/test/element.spec.js
@@ -156,7 +156,7 @@ describe('element.applyProps', () =>
     test('AnimatedSprite.applyProps with updated image props', () =>
     {
         const element = createElement(TYPES.AnimatedSprite, { images: ['./image.png'] });
-        const changed = element.applyProps(element, { images: './image.png' }, { images: './new-image.png' });
+        const changed = element.applyProps(element, { images: ['./image.png'] }, { images: ['./new-image.png'] });
         expect(spy).lastCalledWith('./new-image.png');
     });
 

--- a/packages/react/test/element.spec.js
+++ b/packages/react/test/element.spec.js
@@ -154,6 +154,13 @@ describe('element.applyProps', () =>
         expect(spy).lastCalledWith('./image.png');
     });
 
+    test('AnimatedSprite.applyProps with updated image props', () =>
+    {
+        const element = createElement(TYPES.AnimatedSprite, { images: ['./image.png'] });
+        const changed = element.applyProps(element, { image: './image.png' }, { image: './new-image.png' });
+        expect(spy).lastCalledWith('./new-image.png');
+    });
+
     test('AnimatedSprite.applyProps with textures prop exists', () =>
     {
         const element = createElement(TYPES.AnimatedSprite, { textures: [Texture.from('./image.png')] });


### PR DESCRIPTION
##### Description of change
Currently, updating the image attribute does not update the actual textures on the animated sprite component.  My PR fixes this by checking to see if the images are distinct from the previous iteration, and actually updating them accordingly.

Fixes: <!-- Related issue if relevant -->

##### Pre-Merge Checklist

Will do soon, manually testing still - and looking for some feedback

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
