### PR TITLE
Fix typing of oldProps in applyProps

### DIFF
--- a/packages/react/index.d.ts
+++ b/packages/react/index.d.ts
@@ -350,7 +350,7 @@ declare namespace _ReactPixi
      */
       applyProps?(
           instance: PixiInstance,
-          oldProps: Readonly<P>,
+          oldProps: Readonly<P | object>,
           newProps: Readonly<P>
       ): void;
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
Update the typings of `applyProps` to show that `oldProps` can be an empty object (this happens on the first render).

**Important: This is a breaking change!** It only affects typings though, so users could very easily work around it by adding `@ts-expect-error` comments if they are affected and don't want to adapt their code. Also the change just reflects what is actually passed during runtime, so it might actually benefit the user if they are rechecking their code.

So I think it would be okay to introduce this change without a new major version, but I also totally understand if you want to include this only with the next major release.

Fixes: https://github.com/pixijs/pixi-react/issues/348

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
