### PR TITLE
Fixed pixi.js version in readme and docs

### DIFF
--- a/packages/docs/docs/about.mdx
+++ b/packages/docs/docs/about.mdx
@@ -53,7 +53,7 @@ npm install
 ### 2. Install Pixi-React dependencies:
 
 ```bash
-npm install pixi.js @pixi/react
+npm install pixi.js@7 @pixi/react
 ```
 
 ### 3. Replace App.jsx with the following:

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -41,6 +41,7 @@ If you want to start a new React project from scratch, we recommend [Create Reac
 To add to an existing React application, just install the dependencies:
 
 #### Start New React Project "my-app" with Create React App:
+
 ```bash
 # for typescript add "--template typescript"
 npx create-react-app my-app
@@ -48,18 +49,19 @@ cd my-app
 ```
 
 #### Install Pixi React Dependencies:
+
 ```bash
-npm install pixi.js @pixi/react
+npm install pixi.js@7 @pixi/react
 ```
 
 #### Usage:
-```jsx
-import { BlurFilter } from 'pixi.js';
-import { Stage, Container, Sprite, Text } from '@pixi/react';
-import { useMemo } from 'react';
 
-export const MyComponent = () =>
-{
+```jsx
+import { BlurFilter } from "pixi.js";
+import { Stage, Container, Sprite, Text } from "@pixi/react";
+import { useMemo } from "react";
+
+export const MyComponent = () => {
   const blurFilter = useMemo(() => new BlurFilter(4), []);
 
   return (
@@ -72,7 +74,11 @@ export const MyComponent = () =>
       />
 
       <Container x={400} y={330}>
-        <Text text="Hello World" anchor={{ x: 0.5, y: 0.5 }} filters={[blurFilter]} />
+        <Text
+          text="Hello World"
+          anchor={{ x: 0.5, y: 0.5 }}
+          filters={[blurFilter]}
+        />
       </Container>
     </Stage>
   );


### PR DESCRIPTION
##### Description of change
Because pixi-react doesnt support latest version of pixi.js yet the docs and readme file needed updating to install v7 of pixi.js

Fixes: 
changed 
`npm install pixi.js @pixi/react` to `npm install pixi.js@7 @pixi/react`

##### Pre-Merge Checklist

- [x] Documentation is changed or added
