### PR TITLE
Make `useAsset`'s `onProgress` type optional

### DIFF
--- a/src/hooks/useAsset.ts
+++ b/src/hooks/useAsset.ts
@@ -18,7 +18,7 @@ export function useAsset<T>(
     /** @description Asset options. */
     options: (UnresolvedAsset<T> & AssetRetryOptions) | string,
     /** @description A function to be called when the asset loader reports loading progress. */
-    onProgress: ProgressCallback,
+    onProgress?: ProgressCallback,
 )
 {
     if (typeof window === 'undefined')


### PR DESCRIPTION
##### Description of change
Does what it says on the tin.

Fixes: #502 

##### Pre-Merge Checklist
- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
