### PR TITLE
Check-canvas-instance-in-another-window

### DIFF
--- a/src/core/createRoot.ts
+++ b/src/core/createRoot.ts
@@ -5,6 +5,7 @@ import { ContextProvider } from '../components/Context.ts';
 import { isReadOnlyProperty } from '../helpers/isReadOnlyProperty.ts';
 import { log } from '../helpers/log.ts';
 import { prepareInstance } from '../helpers/prepareInstance.ts';
+import { getIsCanvasElement } from '../helpers/canvas.ts';
 import { reconciler } from './reconciler.ts';
 import { roots } from './roots.ts';
 
@@ -50,7 +51,7 @@ export function createRoot(
     {
         let canvas;
 
-        if (target instanceof HTMLCanvasElement)
+        if (getIsCanvasElement(target))
         {
             canvas = target;
         }

--- a/src/helpers/canvas.ts
+++ b/src/helpers/canvas.ts
@@ -1,0 +1,15 @@
+export function getIsCanvasElement(target: HTMLElement): target is HTMLCanvasElement {
+    if (target instanceof HTMLCanvasElement) return true;
+
+    /**
+     * In case Application is rendered into another window (created with window.open() and rendered into it using React portal)
+     * canvas is instance of openedWindow.HTMLCanvasElement, not global window.HTMLCanvasElement
+     * 
+     * Thus we need to check for that.
+     */
+    const OwnerWindowHTMLCanvasElement = target?.ownerDocument?.defaultView?.HTMLCanvasElement;
+
+    if (!OwnerWindowHTMLCanvasElement) return false;
+
+    return target instanceof OwnerWindowHTMLCanvasElement;
+}

--- a/src/helpers/getAssetKey.ts
+++ b/src/helpers/getAssetKey.ts
@@ -1,0 +1,18 @@
+import type { UnresolvedAsset } from '../typedefs/UnresolvedAsset';
+
+/** Retrieves the key from an unresolved asset. */
+export function getAssetKey<T>(asset: UnresolvedAsset<T>)
+{
+    let assetKey;
+
+    if (typeof asset === 'string')
+    {
+        assetKey = asset;
+    }
+    else
+    {
+        assetKey = (asset.alias ?? asset.src) as string;
+    }
+
+    return assetKey;
+}

--- a/src/hooks/useAsset.ts
+++ b/src/hooks/useAsset.ts
@@ -10,6 +10,7 @@ import type {
 } from 'pixi.js';
 import type { AssetRetryOptions } from '../typedefs/AssetRetryOptions.ts';
 import type { AssetRetryState } from '../typedefs/AssetRetryState.ts';
+import type { ErrorCallback } from '../typedefs/ErrorCallback.ts';
 
 const errorCache: Map<UnresolvedAsset | string, AssetRetryState> = new Map();
 
@@ -19,10 +20,19 @@ export function useAsset<T>(
     options: (UnresolvedAsset<T> & AssetRetryOptions) | string,
     /** @description A function to be called when the asset loader reports loading progress. */
     onProgress: ProgressCallback,
+    /** @description A function to be called when the asset loader reports loading progress. */
+    onError?: ErrorCallback,
 )
 {
     if (typeof window === 'undefined')
     {
+        /**
+         * This is a weird hack that allows us to throw the error during
+         * serverside rendering, but still causes it to be handled appropriately
+         * in Next.js applications.
+         *
+         * @see https://github.com/vercel/next.js/blob/38b3423160afc572ad933c24c86fc572c584e70b/packages/next/src/shared/lib/lazy-dynamic/bailout-to-csr.ts
+         */
         throw Object.assign(Error('`useAsset` will only run on the client.'), {
             digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING',
         });
@@ -42,7 +52,14 @@ export function useAsset<T>(
         // Rethrow the cached error if we are not retrying on failure or have reached the max retries
         if (state && (!retryOnFailure || state.retries > maxRetries))
         {
-            throw state.error;
+            if (typeof onError === 'function')
+            {
+                onError?.(state.error);
+            }
+            else
+            {
+                throw state.error;
+            }
         }
 
         throw Assets

--- a/src/hooks/useAsset.ts
+++ b/src/hooks/useAsset.ts
@@ -2,7 +2,7 @@ import {
     Assets,
     Cache,
 } from 'pixi.js';
-import { getAssetKeyFromOptions } from '../helpers/getAssetKeyFromOptions.ts';
+import { getAssetKey } from '../helpers/getAssetKey.ts';
 
 import type {
     ProgressCallback,
@@ -14,7 +14,10 @@ import type { ErrorCallback } from '../typedefs/ErrorCallback.ts';
 
 const errorCache: Map<UnresolvedAsset | string, AssetRetryState> = new Map();
 
-/** Loads assets, returning a hash of assets once they're loaded. */
+/**
+ * Loads assets, returning a hash of assets once they're loaded.
+ * @deprecated Use `useAssets` instead.
+ */
 export function useAsset<T>(
     /** @description Asset options. */
     options: (UnresolvedAsset<T> & AssetRetryOptions) | string,
@@ -43,7 +46,7 @@ export function useAsset<T>(
         retryOnFailure = true,
     } = typeof options !== 'string' ? options : {};
 
-    const assetKey = getAssetKeyFromOptions(options);
+    const assetKey = getAssetKey(options);
 
     if (!Cache.has(assetKey))
     {

--- a/src/hooks/useAssets.ts
+++ b/src/hooks/useAssets.ts
@@ -1,0 +1,84 @@
+import {
+    Assets,
+    Cache,
+} from 'pixi.js';
+import { getAssetKey } from '../helpers/getAssetKey.ts';
+
+import type { AssetRetryState } from '../typedefs/AssetRetryState.ts';
+import type { UnresolvedAsset } from '../typedefs/UnresolvedAsset.ts';
+import type { UseAssetsOptions } from '../typedefs/UseAssetsOptions.ts';
+
+const errorCache: Map<UnresolvedAsset, AssetRetryState> = new Map();
+
+/** Loads assets, returning a hash of assets once they're loaded. */
+export function useAssets<T>(
+    /** @description Assets to be loaded. */
+    assets: UnresolvedAsset<T>[],
+    /** @description Asset options. */
+    options: UseAssetsOptions = {},
+): T[]
+{
+    if (typeof window === 'undefined')
+    {
+        throw Object.assign(Error('`useAsset` will only run on the client.'), {
+            digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING',
+        });
+    }
+
+    const {
+        maxRetries = 3,
+        onError,
+        onProgress,
+        retryOnFailure = true,
+    } = options;
+
+    const allAssetsAreLoaded = assets.some((asset: UnresolvedAsset<T>) => Cache.has(getAssetKey(asset)));
+
+    if (!allAssetsAreLoaded)
+    {
+        let state = errorCache.get(assets);
+
+        // Rethrow the cached error if we are not retrying on failure or have reached the max retries
+        if (state && (!retryOnFailure || state.retries > maxRetries))
+        {
+            if (typeof onError === 'function')
+            {
+                onError(state.error);
+            }
+            else
+            {
+                throw state.error;
+            }
+        }
+
+        throw Assets
+            .load<T>(assets, (progressValue) =>
+        {
+            if (typeof onProgress === 'function')
+            {
+                onProgress(progressValue);
+            }
+        })
+            .catch((error) =>
+            {
+                if (!state)
+                {
+                    state = {
+                        error,
+                        retries: 0,
+                    };
+                }
+
+                errorCache.set(assets, {
+                    ...state,
+                    error,
+                    retries: state.retries + 1,
+                });
+            });
+    }
+
+    const assetKeys = assets.map((asset: UnresolvedAsset<T>) => getAssetKey(asset));
+    const resolvedAssetsDictionary = Assets.get<T>(assetKeys) as Record<string, T>;
+
+    return assets.map((_asset: UnresolvedAsset<T>, index: number) => resolvedAssetsDictionary[index]);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,6 @@ export * from './global.ts';
 export { extend } from './helpers/extend.ts';
 export { useApp } from './hooks/useApp.ts';
 export { useAsset } from './hooks/useAsset.ts';
+export { useAssets } from './hooks/useAssets.ts';
 export { useExtend } from './hooks/useExtend.ts';
 export { useTick } from './hooks/useTick.ts';

--- a/src/typedefs/ErrorCallback.ts
+++ b/src/typedefs/ErrorCallback.ts
@@ -1,0 +1,1 @@
+export type ErrorCallback = (error: Error) => void;

--- a/src/typedefs/UnresolvedAsset.ts
+++ b/src/typedefs/UnresolvedAsset.ts
@@ -1,0 +1,3 @@
+import type { UnresolvedAsset as PixiUnresolvedAsset } from 'pixi.js';
+
+export type UnresolvedAsset<T = any> = PixiUnresolvedAsset<T> | string;

--- a/src/typedefs/UseAssetsOptions.ts
+++ b/src/typedefs/UseAssetsOptions.ts
@@ -1,0 +1,18 @@
+import { type ErrorCallback } from './ErrorCallback.ts';
+
+import type { ProgressCallback } from 'pixi.js';
+
+export interface UseAssetsOptions
+{
+    /** @description The maximum number of retries allowed before we give up on loading this asset. */
+    maxRetries?: number
+
+    /** @description A function to be called when if the asset loader encounters an error. */
+    onError?: ErrorCallback,
+
+    /** @description A function to be called when the asset loader reports loading progress. */
+    onProgress?: ProgressCallback,
+
+    /** @description Whether to try loading this asset again if it fails. */
+    retryOnFailure?: boolean
+}


### PR DESCRIPTION
##### Description of change

Currently, when creating root and checking if target is `HTMLCanvasElement` we check it with `target instanceof HTMLCanvasElement`

It will break in quite rare-use case, when rendering content into another window (created with `const newWindow = window.open()` using React portal.

In this case - created canvas is instance of `newWindow.HTMLCanvasElement`, not global `HTMLCanvasElement` (or technically `window.HTMLCanvasElement`). As a result - the app will crash.

Use case for such a scenario is eg. creating multi-window Electron applications, when child windows are created using `window.open()`. I described this architecture in detail here: https://pietrasiak.com/creating-multi-window-electron-apps-using-react-portals

<!-- Provide a description of the change below this comment. -->

Fixes: <!-- Related issue if relevant -->

I added `getIsCanvasElement` function that is checking for this case and modified createRoot function to use it when checking if target is canvas.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
