### PR TITLE
fix: reordering children could cause errors

### DIFF
--- a/src/helpers/insertBefore.ts
+++ b/src/helpers/insertBefore.ts
@@ -23,13 +23,14 @@ export function insertBefore(
     {
         const childContainerInstance = childInstance as HostConfig['containerInstance'];
         const childContainer = childInstance as unknown as Container;
+        const beforeChildContainer = beforeChildInstance as unknown as Container;
 
         if (childContainerInstance.parent === parentInstance)
         {
             parentInstance.removeChild(childContainer);
         }
 
-        const index = parentInstance.getChildIndex(childContainer);
+        const index = parentInstance.getChildIndex(beforeChildContainer);
 
         parentInstance.addChildAt(childContainer, index);
     }


### PR DESCRIPTION
##### Description of change
Fixes an issue where inserting a new child or reordering children could cause an uncaught exception.

##### Pre-Merge Checklist
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
