### PR TITLE
Fix `useTick` during initial load when using server components

### DIFF
--- a/src/hooks/useTick.ts
+++ b/src/hooks/useTick.ts
@@ -1,6 +1,6 @@
-import { useEffect } from 'react';
 import { invariant } from '../helpers/invariant.ts';
 import { useApp } from './useApp.ts';
+import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect.ts';
 
 import type { TickerCallback } from 'pixi.js';
 import type { TickCallbackOptions } from '../typedefs/TickCallbackOptions.ts';
@@ -35,7 +35,7 @@ function useTick<T>(
     invariant(typeof callback === 'function', '`useTick` needs a callback function.');
 
     // eslint-disable-next-line consistent-return
-    useEffect(() =>
+    useIsomorphicLayoutEffect(() =>
     {
         const ticker = app?.ticker;
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
`useTick` failed to fire on the first tick in server-rendered environments (such as Next.js applications) because the `useEffect` wasn't being triggered. This is fixed by switching to use `useIsomorphicLayoutEffect` instead.`

Fixes: #506

##### Pre-Merge Checklist
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
