### PR TITLE
Update to Pixi.js 8.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@types/react-reconciler": "0.28.8",
         "canvas": "^2.11.2",
         "husky": "^8.0.0",
-        "pixi.js": "8.2.1",
+        "pixi.js": "8.2.6",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "rollup": "^4.18.0",
@@ -31,7 +31,7 @@
         "vitest": "^1.6.0"
       },
       "peerDependencies": {
-        "pixi.js": "^8.2.1",
+        "pixi.js": "^8.2.6",
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0"
       },
@@ -13602,10 +13602,11 @@
       }
     },
     "node_modules/pixi.js": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.2.1.tgz",
-      "integrity": "sha512-aywwPFJe6+Q10+K+paXB/GBJB7QAXM2ICgEKVIONNLYJQ4byC/pETshfIucTIQr5L56VUZedBAj96D72Bxqskg==",
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.2.6.tgz",
+      "integrity": "sha512-CNfr7CmjIEWJ06e3TBrXBKFpcTPMGUaFdtP4RlMOgNOTkDD6+Bhm728I/EkGAo2vsOVO1YwNFsuORQyD3MngZg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@pixi/colord": "^2.9.6",
         "@types/css-font-loading-module": "^0.0.12",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@types/react-reconciler": "0.28.8",
     "canvas": "^2.11.2",
     "husky": "^8.0.0",
-    "pixi.js": "8.2.1",
+    "pixi.js": "8.2.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "rollup": "^4.18.0",
@@ -81,7 +81,7 @@
     "vitest": "^1.6.0"
   },
   "peerDependencies": {
-    "pixi.js": "^8.2.1",
+    "pixi.js": "^8.2.6",
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0"
   },


### PR DESCRIPTION
##### Description of change
Updates Pixi React to the latest version of Pixi.js. This version exposes a type that's required for Pixi React to continue building.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
