### PR TITLE
fix: add missing constructor overrides; remove redundant overrides

### DIFF
--- a/src/typedefs/ConstructorOverrides.ts
+++ b/src/typedefs/ConstructorOverrides.ts
@@ -1,25 +1,32 @@
-import type {
-    AlphaFilter,
-    AlphaFilterOptions,
-    BlurFilter,
-    BlurFilterOptions,
-    BlurFilterPass,
-    BlurFilterPassOptions,
-    DisplacementFilter,
-    DisplacementFilterOptions,
-    Filter,
-    FilterOptions,
-    NoiseFilter,
-    NoiseFilterOptions,
-    Text,
-    TextOptions,
+import {
+    type BitmapText,
+    type BlurFilter,
+    type BlurFilterOptions,
+    type HTMLText,
+    type HTMLTextOptions,
+    type Mesh,
+    type MeshGeometry,
+    type MeshGeometryOptions,
+    type MeshOptions,
+    type NineSliceSprite,
+    type NineSliceSpriteOptions,
+    type PlaneGeometry,
+    type PlaneGeometryOptions,
+    type Text,
+    type TextOptions,
+    type Texture,
+    type TilingSprite,
+    type TilingSpriteOptions,
 } from 'pixi.js';
 
 export type ConstructorOverrides =
-    | [typeof AlphaFilter, AlphaFilterOptions]
+    | [typeof BitmapText, TextOptions]
     | [typeof BlurFilter, BlurFilterOptions]
-    | [typeof BlurFilterPass, BlurFilterPassOptions]
-    | [typeof DisplacementFilter, DisplacementFilterOptions]
-    | [typeof Filter, FilterOptions]
-    | [typeof NoiseFilter, NoiseFilterOptions]
+    | [typeof HTMLText, HTMLTextOptions]
+    | [typeof Mesh, MeshOptions]
+    | [typeof MeshGeometry, MeshGeometryOptions]
+    | [typeof NineSliceSprite, NineSliceSpriteOptions | Texture]
+    | [typeof PlaneGeometry, PlaneGeometryOptions]
+    | [typeof TilingSprite, TilingSpriteOptions | Texture]
     | [typeof Text, TextOptions];
+


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->
Update constructor overrides to include previously missing overrides and remove redundant overrides.

Searching through types with the following multiline regex in vs code, reveals the following classes in need of overrides:
```
.*@deprecated.*
^.*constructor
```
```
BitmapText
BlurFilter
HTMLText
Mesh
MeshGeometry
NineSliceSprite
PlaneGeometry
TilingSprite
Text
```

Fixes: <!-- Related issue if relevant -->
Types for the components that were previously missing from this list

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
