### PR TITLE
Add support for managing `extensions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,14 @@ Setting `attachToDevtools` to `true` will automatically attach the application t
 
 ###### `defaultTextStyle`
 
-`defaultTextStyle` is a convenience property. Whatever is passed will automatically be assigned to Pixi.js's[`TextStyle.defaultTextStyle`](https://pixijs.download/release/docs/text.TextStyle.html#defaultTextStyle).
+`defaultTextStyle` is a convenience property. Whatever is passed will automatically be assigned to Pixi.js's [`TextStyle.defaultTextStyle`](https://pixijs.download/release/docs/text.TextStyle.html#defaultTextStyle).
 
 > [!NOTE]
 > This property **is not retroactive**. It will only apply to text components created after `defaultTextStyle` is set. Any text components created before setting `defaultTextStyle` will retain the base styles they had before `defaultTextStyle` was changed.
+
+###### `extensions`
+
+`extensions` is an array of extensions to be loaded. Adding and removing items from this array will automatically load/unload the extensions. The first time this is handled happens before the application is initialised. See Pixi.js's [`extensions`](https://pixijs.download/release/docs/extensions.html) documentation for more info on extensions.
 
 ###### `resizeTo`
 

--- a/src/components/Application.ts
+++ b/src/components/Application.ts
@@ -105,19 +105,23 @@ export const ApplicationFunction: ForwardRefRenderFunction<PixiApplication, Appl
             const extensionsToHandle = [...extensions];
             const extensionsState = extensionsRef.current;
 
+            // Check for extensions that have been removed from the array
             for (const extension of extensionsState.values())
             {
                 const extensionIndex = extensionsToHandle.indexOf(extension);
 
+                // If the extension is no longer in the array, we'll remove it from Pixi.js
                 if (extensionIndex === -1)
                 {
                     PixiExtensions.remove(extension);
                     extensionsState.delete(extension);
                 }
 
+                // Since the extension already existed in the state, we can remove it to prevent any further handling
                 extensionsToHandle.splice(extensionIndex, 1);
             }
 
+            // Load any remaining extensions.
             for (const extension in extensionsToHandle)
             {
                 PixiExtensions.add(extension);

--- a/src/components/Application.ts
+++ b/src/components/Application.ts
@@ -1,20 +1,21 @@
-import { TextStyle } from 'pixi.js';
+import {
+    extensions as PixiExtensions,
+    TextStyle,
+} from 'pixi.js';
 import {
     createElement,
     forwardRef,
+    type ForwardRefRenderFunction,
+    type MutableRefObject,
     useCallback,
     useRef,
 } from 'react';
 import { createRoot } from '../core/createRoot';
 import { useIsomorphicLayoutEffect } from '../hooks/useIsomorphicLayoutEffect';
+import { type ApplicationProps } from '../typedefs/ApplicationProps';
+import { type Root } from '../typedefs/Root';
 
 import type { Application as PixiApplication } from 'pixi.js';
-import type {
-    ForwardRefRenderFunction,
-    MutableRefObject,
-} from 'react';
-import type { ApplicationProps } from '../typedefs/ApplicationProps';
-import type { Root } from '../typedefs/Root';
 
 const originalDefaultTextStyle = { ...TextStyle.defaultTextStyle };
 
@@ -29,6 +30,7 @@ export const ApplicationFunction: ForwardRefRenderFunction<PixiApplication, Appl
         children,
         className,
         defaultTextStyle,
+        extensions,
         onInit,
         resizeTo,
         ...applicationProps
@@ -36,6 +38,7 @@ export const ApplicationFunction: ForwardRefRenderFunction<PixiApplication, Appl
 
     const applicationRef: MutableRefObject<PixiApplication | null> = useRef(null);
     const canvasRef: MutableRefObject<HTMLCanvasElement | null> = useRef(null);
+    const extensionsRef: MutableRefObject<Set<any>> = useRef(new Set());
     const rootRef: MutableRefObject<Root | null> = useRef(null);
 
     const updateResizeTo = useCallback(() =>
@@ -94,6 +97,34 @@ export const ApplicationFunction: ForwardRefRenderFunction<PixiApplication, Appl
             });
         }
     }, [onInit]);
+
+    useIsomorphicLayoutEffect(() =>
+    {
+        if (extensions)
+        {
+            const extensionsToHandle = [...extensions];
+            const extensionsState = extensionsRef.current;
+
+            for (const extension of extensionsState.values())
+            {
+                const extensionIndex = extensionsToHandle.indexOf(extension);
+
+                if (extensionIndex === -1)
+                {
+                    PixiExtensions.remove(extension);
+                    extensionsState.delete(extension);
+                }
+
+                extensionsToHandle.splice(extensionIndex, 1);
+            }
+
+            for (const extension in extensionsToHandle)
+            {
+                PixiExtensions.add(extension);
+                extensionsState.add(extension);
+            }
+        }
+    }, [extensions]);
 
     useIsomorphicLayoutEffect(() =>
     {

--- a/src/typedefs/ApplicationProps.ts
+++ b/src/typedefs/ApplicationProps.ts
@@ -26,7 +26,7 @@ export interface BaseApplicationProps
     defaultTextStyle?: TextStyle | TextStyleOptions,
 
     /** @description An array of Pixi extensions to be loaded before initialisation. */
-    extensions?: ExtensionFormatLoose[],
+    extensions?: (ExtensionFormatLoose | any)[],
 
     /** @description A unique key which allows React to manage this component across changes in parent state. */
     key?: Key,

--- a/src/typedefs/ApplicationProps.ts
+++ b/src/typedefs/ApplicationProps.ts
@@ -24,6 +24,9 @@ export interface BaseApplicationProps
     /** @description The default style to be applied to text nodes. */
     defaultTextStyle?: TextStyle | TextStyleOptions,
 
+    /** @description An array of Pixi extensions to be loaded before initialisation. */
+    extensions?: any[],
+
     /** @description A unique key which allows React to manage this component across changes in parent state. */
     key?: Key,
 

--- a/src/typedefs/ApplicationProps.ts
+++ b/src/typedefs/ApplicationProps.ts
@@ -1,6 +1,7 @@
 import type {
     Application,
     ApplicationOptions,
+    ExtensionFormatLoose,
     TextStyle,
     TextStyleOptions,
 } from 'pixi.js';
@@ -25,7 +26,7 @@ export interface BaseApplicationProps
     defaultTextStyle?: TextStyle | TextStyleOptions,
 
     /** @description An array of Pixi extensions to be loaded before initialisation. */
-    extensions?: any[],
+    extensions?: ExtensionFormatLoose[],
 
     /** @description A unique key which allows React to manage this component across changes in parent state. */
     key?: Key,


### PR DESCRIPTION
##### Description of change
Adds the `extensions` property to the `<Application>` component, which allows Pixi React to manage adding/removing extensions for the user.

This is mostly a convenience property. If the user needs to load an extension, then can just as easily use a `useEffect` to run `extensions.add(Extension)`. If they need it to be initialised before the `<Application>`, they can call `extensions.add` and only render the `<Application>` after the extensions have been added. That said... this is way easier. 😝

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
