### PR TITLE
Restore `draw` method being run for `<graphics>` components

### DIFF
--- a/src/constants/PixiReactIgnoredProps.ts
+++ b/src/constants/PixiReactIgnoredProps.ts
@@ -1,3 +1,6 @@
 import { PixiToReactEventPropNames } from './EventPropNames';
 
-export const PixiReactIgnoredProps = Object.freeze(Object.keys(PixiToReactEventPropNames));
+export const PixiReactIgnoredProps = Object.freeze([
+    ...Object.keys(PixiToReactEventPropNames),
+    'draw',
+]);

--- a/src/helpers/createInstance.ts
+++ b/src/helpers/createInstance.ts
@@ -1,4 +1,5 @@
 import { ReactToPixiEventPropNames } from '../constants/EventPropNames';
+import { PixiReactIgnoredProps } from '../constants/PixiReactIgnoredProps';
 import { applyProps } from './applyProps';
 import { catalogue } from './catalogue';
 import { convertStringToPascalCase } from './convertStringToPascalCase';
@@ -30,7 +31,7 @@ export function createInstance(
     // Get the class from an imported Pixi.js namespace
     const PixiComponent = catalogue[name];
 
-    const pixiProps = gentleCloneProps(props);
+    const pixiProps = gentleCloneProps(props, PixiReactIgnoredProps);
 
     // Clone event props
     Object.entries(props).forEach(([key, value]) =>

--- a/src/helpers/gentleCloneProps.ts
+++ b/src/helpers/gentleCloneProps.ts
@@ -1,4 +1,3 @@
-import { PixiReactIgnoredProps } from '../constants/PixiReactIgnoredProps';
 import { ReactIgnoredProps } from '../constants/ReactIgnoredProps';
 import { gentleClone } from './gentleClone';
 
@@ -8,5 +7,5 @@ export function gentleCloneProps(
     additionalIgnoredProps: readonly string[] = [],
 )
 {
-    return gentleClone(props, ReactIgnoredProps.concat(PixiReactIgnoredProps, additionalIgnoredProps));
+    return gentleClone(props, ReactIgnoredProps.concat(additionalIgnoredProps));
 }


### PR DESCRIPTION
##### Description of change
Fixes the issue where `draw` was no longer being run appropriately for `<graphics>` components.

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
