### PR TITLE
Export PixiReactElementProps for typing of user-defined components 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,3 +17,4 @@ export { useAssets } from './hooks/useAssets';
 export { useExtend } from './hooks/useExtend';
 export { useSuspenseAssets } from './hooks/useSuspenseAssets';
 export { useTick } from './hooks/useTick';
+export { PixiReactElementProps } from './typedefs/PixiReactNode';

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -98,6 +98,7 @@ describe('exports', () =>
             'useExtend',
             'useTick',
             'useSuspenseAssets',
+            'PixiReactElementProps'
         );
     });
 });


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Exported PixiReactElementProps type for forwarding props from user-defined components. E.g.:

```tsx
const Test: React.FC<PixiReactElementProps<typeof Graphics> = (props) => {
    return <graphics {...props}/>
}
```

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
