### PR TITLE
bug: allow external context to be accessed from within `<Application>`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
+        "its-fine": "^1.2.5",
         "react-reconciler": "0.31.0"
       },
       "devDependencies": {
@@ -4116,7 +4117,6 @@
       "version": "19.0.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.2.tgz",
       "integrity": "sha512-USU8ZI/xyKJwFTpjSVIrSeHBVAGagkHQKPNbxeWwql/vDmnTIBgx+TJnhFnj1NXgz8XfprU0egV2dROLGpsBEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -4138,7 +4138,6 @@
       "version": "0.28.9",
       "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
       "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*"
@@ -7589,7 +7588,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -11739,6 +11737,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/its-fine": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-1.2.5.tgz",
+      "integrity": "sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0"
       }
     },
     "node_modules/jackspeak": {
@@ -20583,35 +20593,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zustand": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.2.tgz",
-      "integrity": "sha512-8qNdnJVJlHlrKXi50LDqqUNmUbuBjoKLrYQBnoChIbVph7vni+sY+YpvdjXG9YLd/Bxr6scMcR+rm5H3aSqPaw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=18.0.0",
-        "immer": ">=9.0.6",
-        "react": ">=18.0.0",
-        "use-sync-external-store": ">=1.2.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "immer": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "use-sync-external-store": {
-          "optional": true
-        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     ]
   },
   "dependencies": {
+    "its-fine": "^1.2.5",
     "react-reconciler": "0.31.0"
   },
   "devDependencies": {

--- a/src/core/createRoot.tsx
+++ b/src/core/createRoot.tsx
@@ -1,6 +1,5 @@
 import { Application } from 'pixi.js';
 import { type ApplicationOptions } from 'pixi.js';
-import { createElement } from 'react';
 import { type ReactNode } from 'react';
 import { ConcurrentRoot } from 'react-reconciler/constants.js';
 import { ContextProvider } from '../components/Context';
@@ -115,7 +114,11 @@ export function createRoot(
 
             // Update fiber and expose Pixi.js state to children
             reconciler.updateContainer(
-                createElement(ContextProvider, { value: applicationState }, children),
+                (
+                    <ContextProvider value={applicationState}>
+                        {children}
+                    </ContextProvider>
+                ),
                 fiber,
                 null,
                 () => undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,4 +17,5 @@ export { useAssets } from './hooks/useAssets';
 export { useExtend } from './hooks/useExtend';
 export { useSuspenseAssets } from './hooks/useSuspenseAssets';
 export { useTick } from './hooks/useTick';
+export { type ApplicationRef } from './typedefs/ApplicationRef';
 export { type PixiReactElementProps } from './typedefs/PixiReactNode';

--- a/test/e2e/components/Application.test.tsx
+++ b/test/e2e/components/Application.test.tsx
@@ -1,5 +1,4 @@
-import { type Application as PixiApplication } from 'pixi.js';
-import { useEffect } from 'react';
+import { Application as PixiApplication } from 'pixi.js';
 import {
     createContext,
     createRef,
@@ -17,7 +16,10 @@ import { roots } from '../../../src/core/roots';
 import { useApplication } from '../../../src/hooks/useApplication';
 import { type ApplicationRef } from '../../../src/typedefs/ApplicationRef';
 import { isAppMounted } from '../../utils/isAppMounted';
-import { render } from '@testing-library/react';
+import {
+    act,
+    render,
+} from '@testing-library/react';
 
 describe('Application', () =>
 {
@@ -81,7 +83,9 @@ describe('Application', () =>
                 <Application onInit={onInitSpy} />
             );
 
-            render(<TestComponent />);
+            await act(async () => render((
+                <TestComponent />
+            )));
 
             await expect.poll(() => onInitSpy.mock.calls.length).toEqual(1);
         });
@@ -127,7 +131,7 @@ describe('Application', () =>
 
             expect(roots.size).toEqual(0);
 
-            const { unmount } = render(<TestComponent />);
+            const { unmount } = await act(() => render(<TestComponent />));
 
             expect(roots.size).toEqual(1);
 
@@ -178,7 +182,7 @@ describe('Application', () =>
 
             expect(roots.size).toEqual(0);
 
-            const { unmount } = render(<TestComponent />);
+            const { unmount } = await act(() => render(<TestComponent />));
 
             expect(roots.size).toEqual(1);
 

--- a/test/e2e/components/__snapshots__/Application.test.tsx.snap
+++ b/test/e2e/components/__snapshots__/Application.test.tsx.snap
@@ -1,0 +1,7 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Application > mounts correctly 1`] = `
+<div>
+  <canvas />
+</div>
+`;

--- a/test/e2e/hooks/useApplication.test.tsx
+++ b/test/e2e/hooks/useApplication.test.tsx
@@ -7,6 +7,7 @@ import {
 import { Application } from '../../../src/components/Application';
 import { useApplication } from '../../../src/hooks/useApplication';
 import {
+    act,
     render,
     renderHook,
 } from '@testing-library/react';
@@ -47,9 +48,9 @@ describe('useApplication', () =>
             return null;
         };
 
-        render(<TestComponent />, {
+        await act(async () => render(<TestComponent />, {
             wrapper: TestComponentWrapper,
-        });
+        }));
 
         await new Promise<void>((resolve) =>
         {
@@ -68,6 +69,8 @@ describe('useApplication', () =>
 
     it('throws when not in a React Pixi tree', () =>
     {
-        expect(() => renderHook(() => useApplication())).toThrowError(/no context found/i);
+        const renderer = () => act(() => renderHook(() => useApplication()));
+
+        expect(renderer).toThrowError(/no context found/i);
     });
 });

--- a/test/e2e/hooks/useTick.test.tsx
+++ b/test/e2e/hooks/useTick.test.tsx
@@ -8,6 +8,7 @@ import {
 import { Application } from '../../../src/components/Application';
 import { useTick } from '../../../src/hooks/useTick';
 import {
+    act,
     render,
     renderHook,
 } from '@testing-library/react';
@@ -27,7 +28,7 @@ describe('useTick', () =>
                 return null;
             };
 
-            render(<TestComponent />, { wrapper: Application });
+            act(() => render(<TestComponent />, { wrapper: Application }));
 
             await expect.poll(() => useTickSpy.mock.lastCall?.[0]).toBeInstanceOf(Ticker);
         });
@@ -46,7 +47,7 @@ describe('useTick', () =>
                 return null;
             };
 
-            render(<TestComponent />, { wrapper: Application });
+            act(() => render(<TestComponent />, { wrapper: Application }));
 
             await expect.poll(() => useTickSpy.mock.lastCall?.[0]).toBeInstanceOf(Ticker);
         });
@@ -54,8 +55,8 @@ describe('useTick', () =>
 
     it('throws when not in a React Pixi tree', () =>
     {
-        const result = () => renderHook(() => useTick(() => { /* noop */ }));
+        const renderer = () => act(() => renderHook(() => useTick(() => { /* noop */ })));
 
-        expect(result).toThrowError(/no context found/i);
+        expect(renderer).toThrowError(/no context found/i);
     });
 });


### PR DESCRIPTION
##### Description of change
I'm using the `FiberProvider` and `useContextBridge` from [`its-fine`](https://github.com/pmndrs/its-fine) to allow React Contexts that are established outside of an `<Application>` to be available inside of the component.

Fixes: #557 

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
