### PR TITLE
fix(types): update resizeTo ref type

### DIFF
--- a/src/typedefs/ApplicationProps.ts
+++ b/src/typedefs/ApplicationProps.ts
@@ -38,7 +38,7 @@ export interface BaseApplicationProps
     onInit?: (app: Application) => void
 
     /** @description An element (or React ref) to which the application's canvas will be resized. */
-    resizeTo?: HTMLElement | Window | RefObject<HTMLElement>
+    resizeTo?: HTMLElement | Window | RefObject<HTMLElement | null>
 }
 
 export type ApplicationProps = BaseApplicationProps & Partial<{


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

Updates type signature of `resizeTo` on `Application` for react 19 compatability

In react 19 [useRef requires an argument](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#useref-requires-argument) and the type signature has changed slightly. It's a bit more strict by default, so the type needs to be manually widened in order to work for common use cases like the one in the docs:

```jsx
import { Application } from '@pixi/react'
import { useRef } from 'react'
const MyComponent = () => {
  const parentRef = useRef<HTMLDivElement>(null) // <- returns RefObject<HTMLDivElement | null>
  return (
    <div ref={parentRef}>
      <Application resizeTo={parentRef} /> 
      {/* ^ will throw an error if we ask for RefObject<HTMLElement> - null is not assignable to element */}
    </div>
  )
}
```

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] ~~Tests and/or benchmarks are included~~ N/A
- [x] ~~Documentation is changed or added~~ N/A
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
