### PR TITLE
fix: Remove union types from ConstructorOptions

### DIFF
--- a/src/typedefs/ConstructorOptions.ts
+++ b/src/typedefs/ConstructorOptions.ts
@@ -1,4 +1,7 @@
+import { type GraphicsContext, type Texture } from 'pixi.js';
 import { type ConstructorOverrides } from './ConstructorOverrides';
+
+type ConstructorOptionExcludes = GraphicsContext | Texture;
 
 /**
  * We're adding a specific options type overrides for some components because their deprecated overloads get in the way.
@@ -7,6 +10,6 @@ import { type ConstructorOverrides } from './ConstructorOverrides';
 export type ConstructorOptions<T extends new (...args: any[]) => any> =
     Extract<ConstructorOverrides, { 0: T }> extends [T, infer R]
         ? unknown extends R
-            ? ConstructorParameters<T>[0]
+            ? NonNullable<Exclude<ConstructorParameters<T>[0], ConstructorOptionExcludes>>
             : R
         : unknown;

--- a/src/typedefs/ConstructorOverrides.ts
+++ b/src/typedefs/ConstructorOverrides.ts
@@ -16,7 +16,6 @@ import {
     type PlaneGeometryOptions,
     type Text,
     type TextOptions,
-    type Texture,
     type TilingSprite,
     type TilingSpriteOptions,
 } from 'pixi.js';
@@ -28,8 +27,8 @@ export type ConstructorOverrides =
     | [typeof HTMLText, HTMLTextOptions]
     | [typeof Mesh, MeshOptions]
     | [typeof MeshGeometry, MeshGeometryOptions]
-    | [typeof NineSliceSprite, NineSliceSpriteOptions | Texture]
+    | [typeof NineSliceSprite, NineSliceSpriteOptions]
     | [typeof PlaneGeometry, PlaneGeometryOptions]
-    | [typeof TilingSprite, TilingSpriteOptions | Texture]
+    | [typeof TilingSprite, TilingSpriteOptions]
     | [typeof Text, TextOptions];
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Container, Sprite and Graphics all have constructors that union the options with Texture | GraphicsContext | undefined, these  types are not valid as props for a component, and the union was causing Omit and other utils to produce incorrect types when trying to extend the builtin types.

Excluding the unioned types from ConstructorOptions eleminates potential incorrect props and allows for Pick, Omit, etc to work as expected.

Fixes: <!-- Related issue if relevant -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
