### PR TITLE
Add 'writable' descriptor check to isReadOnlyProperty

### DIFF
--- a/src/helpers/isReadOnlyProperty.ts
+++ b/src/helpers/isReadOnlyProperty.ts
@@ -6,5 +6,5 @@ export function isReadOnlyProperty(
     const prototype = Object.getPrototypeOf(objectInstance);
     const propertyDescriptor = Object.getOwnPropertyDescriptor(prototype, propertyKey);
 
-    return !(typeof propertyDescriptor === 'undefined' || propertyDescriptor.set);
+    return !(typeof propertyDescriptor === 'undefined' || propertyDescriptor.writable || propertyDescriptor.set);
 }


### PR DESCRIPTION
##### Add `writable` descriptor check to isReadOnlyProperty

Addresses an issue where normal writable object properties were being incorrectly identified as read-only and not updating in `applyProps()`.

Fixes: https://github.com/pixijs/pixi-react/issues/563

##### Pre-Merge Checklist

- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
