### PR TITLE
Do not use extension on ConcurrentRoot import

### DIFF
--- a/src/core/createRoot.tsx
+++ b/src/core/createRoot.tsx
@@ -1,7 +1,7 @@
 import { Application } from 'pixi.js';
 import { type ApplicationOptions } from 'pixi.js';
 import { type ReactNode } from 'react';
-import { ConcurrentRoot } from 'react-reconciler/constants.js';
+import { ConcurrentRoot } from 'react-reconciler/constants';
 import { ContextProvider } from '../components/Context';
 import { isReadOnlyProperty } from '../helpers/isReadOnlyProperty';
 import { log } from '../helpers/log';


### PR DESCRIPTION
This is causing issues with attempting to use the package from skypack

<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
<!-- Provide a description of the change below this comment. -->

Fixes: <!-- Related issue if relevant -->

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
