### PR TITLE
Bundle @pixi/react for use without bundler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,8 @@
         "react-dom": "^19.0.0",
         "rollup": "^4.18.0",
         "rollup-plugin-esbuild": "^6.1.1",
+        "rollup-plugin-inject-process-env": "^1.3.1",
+        "rollup-plugin-peer-deps-external": "^2.2.4",
         "rollup-plugin-sourcemaps": "^0.6.3",
         "typescript": "^5.4.5",
         "vitest": "^2.0.0"
@@ -30868,6 +30870,24 @@
       "peerDependencies": {
         "esbuild": ">=0.18.0",
         "rollup": "^1.20.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+      }
+    },
+    "node_modules/rollup-plugin-inject-process-env": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject-process-env/-/rollup-plugin-inject-process-env-1.3.1.tgz",
+      "integrity": "sha512-kKDoL30IZr0wxbNVJjq+OS92RJSKRbKV6B5eNW4q3mZTFqoWDh6lHy+mPDYuuGuERFNKXkG+AKxvYqC9+DRpKQ==",
+      "dev": true,
+      "dependencies": {
+        "magic-string": "^0.25.7"
+      }
+    },
+    "node_modules/rollup-plugin-peer-deps-external": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-peer-deps-external/-/rollup-plugin-peer-deps-external-2.2.4.tgz",
+      "integrity": "sha512-AWdukIM1+k5JDdAqV/Cxd+nejvno2FVLVeZ74NKggm3Q5s9cbbcOgUPGdbxPi4BXu7xGaZ8HG12F+thImYu/0g==",
+      "dev": true,
+      "peerDependencies": {
+        "rollup": "*"
       }
     },
     "node_modules/rollup-plugin-sourcemaps": {

--- a/package.json
+++ b/package.json
@@ -91,6 +91,8 @@
     "react-dom": "^19.0.0",
     "rollup": "^4.18.0",
     "rollup-plugin-esbuild": "^6.1.1",
+    "rollup-plugin-inject-process-env": "^1.3.1",
+    "rollup-plugin-peer-deps-external": "^2.2.4",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "typescript": "^5.4.5",
     "vitest": "^2.0.0"


### PR DESCRIPTION
<!--
Thank you for your pull request!

Bug fixes and new features should include tests and possibly benchmarks.

Before submitting please read:

Contributors guide: https://github.com/pixijs/pixijs/blob/dev/.github/CONTRIBUTING.md
Code of Conduct: https://github.com/pixijs/pixijs/blob/dev/.github/CODE_OF_CONDUCT.md
-->

##### Description of change
Update the Rollup config to output 3 bundles.
- `lib`: Existing standard lib
- `dist-dev`: @pixi/react bundled in development
- `dist-prod` @pixi/react bundled in production and minified

The ouput in the dist folder bundles all dependencies [its-fine, react-reconciler], while the lib remains unbundled.

Please provide feedback on structure for maintainability, may be better to flatten into more explicit outputs.

Fixes: <!-- Related issue if relevant -->

Example Usage:
```html
<html>
    <head>
        <title>@pixi/react</title>
        <style>
            body,
            div {
                height: 100vh;
                margin: 0;
                display: grid;
                place-items: center;
            }
        </style>
        <script type="importmap">
            {
                "imports": {
                    "react": "https://esm.sh/react@19.0.0",
                    "react/jsx-runtime": "https://esm.sh/react@19.0.0/jsx-runtime.js",
                    "react-dom/client": "https://esm.sh/react-dom@19.0.0/client",
                    "pixi.js": "https://esm.sh/pixi.js@8.2.6/dist/pixi.min.mjs",
                    "@pixi/react": "https://esm.sh/@pixi/react@beta/dist/pixi-react.min.mjs"
                }
            }
        </script>
        <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
    </head>
    <body>
        <div id="root"></div>
        <script type="text/babel" data-type="module">
            import React, { useRef, Suspense } from "react";
            import { createRoot } from "react-dom/client";

            import { Text, TextStyle } from "pixi.js";
            import { Application, extend } from "@pixi/react";

            extend({ Text });

            const TEXT_STYLE = new TextStyle({
                align: "left",
                fill: "0xf7f7f7",
                fontSize: 32,
            });

            const App = () => {
                return (
                    <Application background={"#1099bb"} resizeTo={window}>
                        <pixiText
                            text="Hello @pixi/react!"
                            style={TEXT_STYLE}
                            anchor={0}
                            x={20}
                            y={20}
                        />
                    </Application>
                );
            };

            const root = createRoot(document.getElementById("root"));
            root.render(<App />);
        </script>
    </body>
</html>
```

##### Pre-Merge Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Tests and/or benchmarks are included
- [ ] Documentation is changed or added
- [ ] Lint process passed (`npm run lint`)
- [ ] Tests passed (`npm run test`)
