### PR TITLE
Update `its-fine`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "docs"
       ],
       "dependencies": {
-        "its-fine": "^1.2.5",
+        "its-fine": "^2.0.0",
         "react-reconciler": "0.31.0"
       },
       "devDependencies": {
@@ -88,6 +88,18 @@
       "peerDependencies": {
         "pixi.js": "^8.2.6",
         "react": ">=19.0.0"
+      }
+    },
+    "docs/node_modules/its-fine": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-1.2.5.tgz",
+      "integrity": "sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -20552,15 +20564,15 @@
       }
     },
     "node_modules/its-fine": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-1.2.5.tgz",
-      "integrity": "sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
       "license": "MIT",
       "dependencies": {
-        "@types/react-reconciler": "^0.28.0"
+        "@types/react-reconciler": "^0.28.9"
       },
       "peerDependencies": {
-        "react": ">=18.0"
+        "react": "^19.0.0"
       }
     },
     "node_modules/jackspeak": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     ]
   },
   "dependencies": {
-    "its-fine": "^1.2.5",
+    "its-fine": "^2.0.0",
     "react-reconciler": "0.31.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I've updated `its-fine` to 2.x.x. This removes the issue where `its-fine` would overwrite `console.error`, causing some weirdness with the way stack traces were reported.