### PR TITLE
fix: add missing dependencies to useTick

### DIFF
--- a/src/hooks/useTick.ts
+++ b/src/hooks/useTick.ts
@@ -61,8 +61,10 @@ export function useTick<T>(
             };
         }
     }, [
+        app?.ticker,
         callback,
         context,
+        isEnabled,
         isInitialised,
         priority,
     ]);


### PR DESCRIPTION
`useTick` has missing dependencies that are detected with `eslint-plugin-react-hooks`, accept the recommended fix from the plugin.

Fixes #587