### PR TITLE
chore: config eslint-plugin-react-hooks

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,3 +1,4 @@
+import reactHooks from 'eslint-plugin-react-hooks';
 import pixiConfig from '@pixi/eslint-config';
 
 export default [
@@ -40,4 +41,13 @@ export default [
             'dot-notation': 0,
         },
     },
+    {
+        ...reactHooks.configs['recommended-latest'],
+        rules: {
+            ...reactHooks.configs['recommended-latest'].rules,
+            'react-hooks/exhaustive-deps': ['warn', {
+                additionalHooks: '(useIsomorphicLayoutEffect)'
+            }]
+        }
+    }
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@types/react-reconciler": "^0.28.9",
         "@vitejs/plugin-react": "^4.3.1",
         "@vitest/browser": "^2.0.4",
+        "eslint-plugin-react-hooks": "^5.2.0",
         "husky": "^8.0.0",
         "jsdom": "^25.0.0",
         "pixi.js": "8.2.6",
@@ -16070,6 +16071,19 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
       }
     },
     "node_modules/eslint-plugin-simple-import-sort": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@types/react-reconciler": "^0.28.9",
     "@vitejs/plugin-react": "^4.3.1",
     "@vitest/browser": "^2.0.4",
+    "eslint-plugin-react-hooks": "^5.2.0",
     "husky": "^8.0.0",
     "jsdom": "^25.0.0",
     "pixi.js": "8.2.6",


### PR DESCRIPTION
Adds [eslint-plugin-react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks) and configures `useIsomorphicLayoutEffect` as an additional hook to run exhaustive-deps on.