### PR TITLE
fix: externalize dependencies for packaged lib

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -52,7 +52,7 @@ function convertPackageNameToRegExp(packageName)
     return new RegExp(`^${escapeRegExp(packageName)}(/.+)?$`);
 }
 
-const external = ({ bundleDeps = true } = {}) => (bundleDeps ? [] : Object.keys(dependencies).map(convertPackageNameToRegExp));
+const external = ({ bundleDeps = false } = {}) => (bundleDeps ? [] : Object.keys(dependencies).map(convertPackageNameToRegExp));
 
 const targets = {
     lib: {


### PR DESCRIPTION
CRA and Parcel have bundle errors due to a bug in the bundle refactor.

This change restores  proper externalization of `its-fine` and `react-reconciler` in the `lib` bundle.