### PR TITLE
fix: revert import change for react-reconciler/constants

### DIFF
--- a/src/core/createRoot.tsx
+++ b/src/core/createRoot.tsx
@@ -1,7 +1,7 @@
 import { Application } from 'pixi.js';
 import { type ApplicationOptions } from 'pixi.js';
 import { type ReactNode } from 'react';
-import { ConcurrentRoot } from 'react-reconciler/constants';
+import { ConcurrentRoot } from 'react-reconciler/constants.js';
 import { ContextProvider } from '../components/Context';
 import { isReadOnlyProperty } from '../helpers/isReadOnlyProperty';
 import { log } from '../helpers/log';


### PR DESCRIPTION
Reverts #576

The original change  is now superseeded by #577 and should no longer be needed.
The final solution was to bundle the reconciler into the production min.mjs file we ship for use in codepen.

Users are reporting errors with this change https://github.com/pixijs/pixi-react/issues/614, though I am unable to reproduce locally.

As the original change was a workaround for bundling and some local bundler seems sensitive to this change it is best to revert. Tested locally in vite and had no issues with this change.
