### PR TITLE
fix initialization of extensions

### DIFF
--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -119,7 +119,7 @@ const ApplicationImplementation = forwardRef<ApplicationRef, ApplicationProps>(f
             }
 
             // Load any remaining extensions.
-            for (const extension in extensionsToHandle)
+            for (const extension of extensionsToHandle)
             {
                 PixiExtensions.add(extension);
                 extensionsState.add(extension);

--- a/src/components/Application.tsx
+++ b/src/components/Application.tsx
@@ -3,6 +3,7 @@ import {
     useContextBridge,
 } from 'its-fine';
 import {
+    type ExtensionFormat,
     type Application as PixiApplication,
     extensions as PixiExtensions,
     TextStyle,
@@ -45,7 +46,7 @@ const ApplicationImplementation = forwardRef<ApplicationRef, ApplicationProps>(f
 
     const applicationRef: RefObject<PixiApplication | null> = useRef(null);
     const canvasRef = useRef<HTMLCanvasElement>(null);
-    const extensionsRef = useRef<Set<any>>(new Set());
+    const extensionsRef = useRef<Set<ExtensionFormat>>(new Set());
 
     useImperativeHandle(forwardedRef, () => ({
         getApplication()

--- a/test/e2e/components/Application.test.tsx
+++ b/test/e2e/components/Application.test.tsx
@@ -1,4 +1,4 @@
-import { Application as PixiApplication } from 'pixi.js';
+import { Application as PixiApplication, extensions as PixiExtensions, ExtensionType } from 'pixi.js';
 import {
     createContext,
     createRef,
@@ -194,5 +194,25 @@ describe('Application', () =>
 
             expect(roots.size).toEqual(0);
         });
+    });
+
+    it('loads extensions provided in the extensions prop', async () =>
+    {
+        const customLoader = {
+            extension: {
+                type: ExtensionType.LoadParser,
+                name: 'custom-loader',
+                priority: 100,
+            },
+        };
+
+        const addSpy = vi.spyOn(PixiExtensions, 'add');
+
+        await act(async () => render((
+            <Application extensions={[customLoader]} />
+        )));
+
+        expect(addSpy).toHaveBeenCalledWith(customLoader);
+        addSpy.mockRestore();
     });
 });


### PR DESCRIPTION
I believe there is a bug in the `Application` component. When it's trying to initalize the `extensions` prop it should use for *of* to get the values, rather than for *in*, which uses the keys.

The following is the bug that comes back from pixi's `normalizeExtension` code when you specify an array of extensions as a prop of `Application`, note that the param `ext` has a value of `0` (the first key in the array)

<img width="458" height="227" alt="image" src="https://github.com/user-attachments/assets/6cd3b79d-4015-4145-9162-174f9f4e0857" />

ps. I agree this javascript language feature is quite stupid. [Array.forEach](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/forEach) is much superior, imo :)